### PR TITLE
Feature - Issue 1 - Update docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,12 +2,28 @@ name: ci
 
 on:
   push:
-    branches: master
+    tags: 'releases/*'
 
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
+      -
+         name: Set up variables
+         id: vars
+         env:
+           DOCKER_REPO: cfei/zookeeper
+         shell: bash
+         run: |
+           echo ${GITHUB_REF}
+           echo ${GITHUB_REF:19}
+           echo ${GITHUB_REF: -4}
+           if [ ${GITHUB_REF: -4} == 'beta' ] 
+           then
+             echo ::set-output name=DOCKER_TAG::${DOCKER_REPO}:${GITHUB_REF:19}
+           else
+             echo ::set-output name=DOCKER_TAG::${DOCKER_REPO}:${GITHUB_REF:19},${DOCKER_REPO}:latest
+           fi
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -26,8 +42,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: cfei/zookeeper:latest-multiarch
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          tags: ${{ steps.vars.outputs.DOCKER_TAG }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Github action now publishes docker image on tag creation, and it uses the tag name to specify the docker image tag.